### PR TITLE
Update very minor issues in sitemanual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # WILL-Website-Manual
 A complete reference to WILL website structure, content creation, and editorial guidelines for authors, project managers, designers
+
+The website manual is generated from github pages by Jekyll, and is available as public html pages at http://willpublicmedia.github.io/sitemanual/

--- a/digitalmedia.html
+++ b/digitalmedia.html
@@ -138,7 +138,7 @@ description: "Digital Media Essentials - How to Work with Media for the Web"
           <div class="page-header">
             <h2>Audio Encoding Specification</h2>
           </div>
-          <p class="lead">If you use the WILL automatic encoding system for audio files, you never have to worry about encoding your file to the correct format for the web.  Please use that system always. </p> 
+          <p class="lead">If you use the WILL automatic encoding system for audio files, you never have to worry about encoding your files to the correct format for the web.  Please use that system always, as it will automatically move the source wav file to permanent storage.</p> 
           <p>For the sake of clarity and documentation, here is the audio encoding spec we use for all online audio:</p>  
           <ul>
             <li>File Format: mp3</li>

--- a/digitalmedia.html
+++ b/digitalmedia.html
@@ -143,7 +143,7 @@ description: "Digital Media Essentials - How to Work with Media for the Web"
           <ul>
             <li>File Format: mp3</li>
             <li>Total Bitrate: 64 Kbps</li>
-            <li>Bit Depth: 16 bits/li>
+            <li>Bit Depth: 16 bits</li>
             <li>Sampling Rate: 44.1 KHz</li>
             <li>Audio Channels: 1 (mono)</li>
           </ul>    


### PR DESCRIPTION
**Issues addressed in this update:**
- missing opening </li> bracket on http://willpublicmedia.github.io/sitemanual/digitalmedia/
- text unclear about why it's important to use the audio automation system to create mp3 files
- README file doesn't explain we're using Jekyll

**What Was Done**
- fixed the missing opening bracket
- added some clarifying text concerning permanent storage of wav files from the audio automation system
- added to the README file to explain we're using Jekyll 