### PR TITLE
Update _config.yml file to correct for GitHub error message on merge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ urlimg: "/sitemanual/assets/img/"
 
 # Build settings
 markdown: kramdown
-highlighter: pygments
+highlighter: rouge
 permalink: pretty
 paginate: 5
 exclude: ["README.md"]


### PR DESCRIPTION
## What is the issue?
- We've been getting a Page build warning message from GitHub on each merge.
- This is that message: "You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset"
## What was done
- Changed the value of the highlighter key to "rouge"