### PR TITLE
rename pages.html

### DIFF
--- a/unique-pages.html
+++ b/unique-pages.html
@@ -46,7 +46,7 @@ description: "How to Manage WILL Pages"
     <!-- About WILL Pages    ================================================== -->
         <section id="will-pages">
           <div class="page-header">
-            <h1>WILL Pages</h1>
+            <h1>Unique Pages</h1>
           </div>
           <p class="lead">The website contains many unique pages that are maintained in the channel called WILL Pages. Each entry in WILL Pages is given a Pages URI, which is different from a normal EE entry url in that it can be anything. The entry is also assigned to a specific template via the Template dropdown list. For example our About page is a WILL Page entry given the Pages URI of “/about”, and assigned to the template “pages/about”. </p>
           <p>WILL Pages are stand-alone web pages that are mostly static. They could be hand-coded but that would require any edits to be made by the Webmaster, so we're using the EE Pages Module to maintain them. There are a few <strong>very important pages</strong> with particular quirks.</p>


### PR DESCRIPTION
## What was done

Renamed pages.html to unique-pages.html and updated the h1 title to reflect this change

## Why 

- This page is really about unique pages so...
- Also we need a new manual page in the Content Authors section to explain EE Pages and how to use them.