### PR TITLE
fix bonehead image path errors

### DIFF
--- a/pages.html
+++ b/pages.html
@@ -50,20 +50,20 @@ description: "How to Publish a single Page"
             <li>In the dropdown list of sections to post to, select WILL Pages.</li>
           </ol>
           <p>The entry form for WILL Pages is almost the same as for any other post, with one exception. Near the top of the entry form you'll see a <em>Pages URI</em> field and a <em>Template</em> dropdown list:</p>   
-          <img src="assets/img/EE-page-edit-screen.png" alt="WILL Pages entry form">
+          <img src="{{ site.urlimg }}EE-page-edit-screen.png" alt="WILL Pages entry form">
           <p>In the <em>Pages URI</em> field, you can assign a custom url to the page you're creating. Enter only the part of the url after _will.illinois.edu_. In the case of the <em>About</em> page, we want to final url to be <em>will.illinois.edu/about</em>, so we just need to enter <em>/about</em> in the <em>Pages URI</em> field.</p>
           <p>You can make the <em>Pages URI</em> as simple or complex as needed. For example let's say you want a page for WILL's history, and you want it associated with "About WILL." When you create the history page, just give it a <em>Pages URI</em> of <em>/about/history</em>. You can do the same thing with <em>/about/location</em>, <em>/about/mission</em>, etc. This creates a heirarchy of pages that makes sense to both humans and search engines.</p>
           <p><em>You can use any uri you want, so long as it's unique. If you pick one that already exists, ExpressionEngine will complain and not let you do it.</em></p>
           <h3>Now select a template for the page</h3>
           <p>The template is the "shell" that will go around the page content, like the navigation, and logo (AM, FM, TV, Community, Agriculture, etc.). Some templates have sidebars, and some are full-width. You can tell what kind of template it is by the name of the template. Click the dropdown and scroll down to choose the template you want for the page:</p>
-          <img src="assets/img/pages-entry-template-dropdown.png" alt="Pages template dropdown list">
+          <img src="{{ site.urlimg }}pages-entry-template-dropdown.png" alt="Pages template dropdown list">
           <p>If you choose a template and it isn't what you want, you can easily edit the WILL Page entry and select another template.</p>
           <h3>Special purpose templates</h3>
           <p>The <em>Template</em> dropdown list provides two very special purpose templates you can use as needed:</p>
           <h4>full_width_html</h4>
           <p>This <em>pages/full-width</em> template is a kind of shell with only the WILL top navigation and the footer. For the page content you can design anything you want just using the main Description field.</p>
           <p>For example, let's say you want to design a page with a unique set of columns, and you're comfortable coding the columns yourself using html and the <a href="https://getbootstrap.com/docs/3.3/">Bootstrap grid framework</a> which we use for the website. Select the <em>pages/full_width_html</em> template, switch the Description field to Source view, and you can add just about any code you want including custom styles. Here's an example entry using the <em>full_width_html</em> template:</p>
-          <img src="assets/img/pages-entry-template-dropdown" alt="pages template dropwdown list">
+          <img src="{{ site.urlimg }}page-source-html-editing.png" alt="pages template dropwdown list">
           <p>Here's the page for this entry: <a href="https://will.illinois.edu/greatamericanread">https://will.illinois.edu/greatamericanread</a>. As you can see it has some custom styles, including a 2x2 grid for the videos. The custom CSS and the Bootstrap markup were added in the entry itself.</p>
           <h4>Redirects</h4>
           <p>The <em>pages/redirect</em> template has one purpose: redirecting the <em>Pages URI</em> to another url. This is useful in cases where a simple WILL url is needed, like <em>will.illinois.edu/renewmygift</em>, and you want it redirected to another url for a donation form or whatever.</p>
@@ -77,7 +77,7 @@ description: "How to Publish a single Page"
               <li>Save the entry and you're done. No other fields are needed for redirects.</li>
             </ol>
             <p>Here's an example entry showing the fields needed to create a redirect. Unneeded fields are collapsed in this screenshot just to get them out of the way:</p>
-            <img src="assets/img/pages-redirect-entry.png" alt="a website entry showing fields needed for a redirect">
+            <img src="{{ site.urlimg }}pages-redirect-entry.png" alt="a website entry showing fields needed for a redirect">
 
       </section>
                                       


### PR DESCRIPTION
# What was done
- replaced `<img src="assets/img/` with the correct Jekyll path for images which is `<img src="{{ site.urlimg }}`
- replaced one incorrect image filename, yay.