### PR TITLE
updated menu for site managers

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -44,7 +44,7 @@
                   <b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">
-                  <li><a href="{{"managers" | prepend: site.baseurl }}">Managing the Site Manual</a></li>
+                  <li><a href="{{"managers" | prepend: site.baseurl }}">How the Site Manual works</a></li>
                   <li><a href="{{"framework" | prepend: site.baseurl }}">CMS Framework</a></li>
                   <li><a href="{{"unique-pages" | prepend: site.baseurl }}">Unique Pages</a></li>
 				  <li><a href="{{"obscura" | prepend: site.baseurl }}">Website Obscura</a></li>


### PR DESCRIPTION
## What was done
Changed the wording of the first menu item in the dropdown For Site Managers, to say "How the Site Manual works"

## Why
To make more obvious that site managers should definitely look at this page for key information
