### PR TITLE
added a gist for the template code, plus a few minor text edits

### DIFF
--- a/obscura.html
+++ b/obscura.html
@@ -85,10 +85,10 @@ description: "How to do hard to find things"
         <p>This is different from a regular tag page in several ways: 
           <ul>
             <li>The regular tag page for the tag "snap-series" displays the same content but doesn't have a unique brand and description, and there's no way to add these without changing the way all regular tag pages work. We want the SNAP series page to look like a special project.</li>
-            <li>Regular tag pages behave differently in other ways. For example, the <a href="https://will.illinois.edu/tags/snap">tag page for "snap"</a> displays all posts tagged snap, and that's more than we want in our special series. It only displays the post titles, and includes content from all channels. We may or may not want that for our special series.</li>
+            <li>Regular tag pages behave differently in other ways. For example, the <a href="https://will.illinois.edu/tags/snap">tag page for "snap"</a> displays all posts tagged snap, and that's more than we want in our special series. Regular tag pages only display the post titles, and include content from all channels. We may not want that for our special series.</li>
             <li>We also have some regular tag pages designed to display tag-based content only from specific channels. For example the template <code>tags/news</code> displays only News channel content based on its tag, like <a href="https://will.illinois.edu/tags/news/affordable-care-act/">https://will.illinois.edu/tags/news/affordable-care-act/</a>. In this case "affordable-care-act" in the 3rd url segment is the url-safe representation of the tag "Affordable Care Act". And the template <code>tags/news</code> is set to only display News content with that or any other tag.</li>
           </ul>
-        <p>But with a special project we need more than a regular tag page. It needs a description at the top, and it can display posts from one or more channels that you specify when setting it up. Here's how to do that.</p>
+        <p>But with a special project we need more than a regular tag page. The project page needs a description at the top, and it can display posts from any channels you specify when setting it up. Here's how to do that.</p>
         <h3>Setting up a Tag-based Special Project Page</h3>
         <p>Here are the ingredients:</p>
         <ol>
@@ -98,16 +98,7 @@ description: "How to do hard to find things"
         </ol>
         <h4>The Template</h4>
         <p>You can copy the page template from another tag-based project (like news/snapseries), but here's the basic idea:</p>
-        <code>
-          {preload_replace:pre_logo="IPM_Logo_Main.png"}
-          {preload_replace:pre_title="Stories on the Supplemental Nutrition Assistance Program from Illinois Public Media"}
-          {preload_replace:pre_description="Stories on the Supplemental Nutrition Assistance Program from Illinois Public Media and WILL-AM-FM-TV-Online, the public media service at the University of Illinois"}
-          {preload_replace:pre_sidebar_template="embeds/_embed_sidebar_news"}
-          {preload_replace:pre_channel="features|news|newsnational|21stshow"}
-          {preload_replace:pre_channel_description_entry_id="48841"}
-          {preload_replace:pre_tags="snap-series"}
-          {sn_articles_by_tag}
-        </code>
+        <script src="https://gist.github.com/jackbrighton/0f9d33b8eec40b98539dff7511651b33.js"></script>
         <p>Include the correct Channel Description id for the project, and make sure to use url-safe tags in the pre-tags variable. Probably use only one tag, to limit entries to just those wanted for the series.</p>
         <p>Include the specific channels from which content will display on the project page.</p>
         <p>Edit the text for the other variables as needed. The pre_title and pre_description variables are used for metadata in the pages head section, and nowhere else.</p>


### PR DESCRIPTION
## What was done
- Replaced a block of code in code tags with a gist containing the code.
- Made a few text edits for clarity

## Why
- The block of code in code tags displayed inline which is not what we want. Should have used a gist in the first place.
- Because, editing text is good.